### PR TITLE
replace fail! with panic!

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -66,7 +66,7 @@ impl INotify {
 		match result {
 			0  => Ok(()),
 			-1 => Err(IoError::last_error()),
-			_  => fail!(
+			_  => panic!(
 				"unexpected return code from inotify_rm_watch ({})", result)
 		}
 	}
@@ -116,7 +116,7 @@ impl INotify {
 						Some(string)
 							=> string.to_string(),
 						None =>
-							fail!("Failed to convert C string into Rust string")
+							panic!("Failed to convert C string into Rust string")
 					}
 				}
 				else {


### PR DESCRIPTION
A recent change to Rusts master branch renamed fail! to panic! which causes inotify-rs to fail to compile. This pull requests fixes this small problem.
