### PR TITLE
Fixed deprecated syntax

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -104,7 +104,7 @@ impl INotify {
 	pub fn available_events(&mut self) -> IoResult<&[Event]> {
 		self.events.clear();
 
-		let mut buffer = [0u8, ..1024];
+		let mut buffer = [0u8; 1024];
 		let len = unsafe {
 			ffi::read(
 				self.fd,


### PR DESCRIPTION
[0, ..1024] syntax is now deprecated. Fixed using std::iter::repeat.

I tried out `Vec::with_capacity` instead and passing `buffer.capacity()` instead of `buffer.len()` to get rid of initializing the vec with zeros, but got a failed assertion from slice.rs, so I guess the initialization is necessary.