### PR TITLE
Fixed build error (std::io => std::old_io)

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -19,7 +19,7 @@ use std::ffi::{
     CString,
 };
 use std::mem;
-use std::io::{
+use std::old_io::{
     EndOfFile,
     IoError,
     IoResult

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -4,7 +4,7 @@
 extern crate inotify;
 
 
-use std::io::File;
+use std::old_io::File;
 use std::os::tmpdir;
 
 use inotify::INotify;


### PR DESCRIPTION
std::io has moved to std::old_io, as outlined here:

http://internals.rust-lang.org/t/psa-io-old-io/1403