### PR TITLE
Update for std::path reform in rustc version ba2f13ef0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![crate_type = "lib"]
 #![warn(missing_docs)]
 #![stable]
-#![feature(collections, core, libc, io, os, path, std_misc)]
+#![feature(collections, core, libc, io, os, std_misc)]
 
 //! Binding and wrapper for inotify.
 //!

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,13 +1,15 @@
 // This test suite is incomplete and doesn't cover all available functionality.
 // Contributions to improve test coverage would be highly appreciated!
 
-#![feature(collections, io, os, path)]
+#![feature(io, env, path, std_misc, core)]
 
 extern crate inotify;
 
 
 use std::old_io::File;
-use std::os::tmpdir;
+use std::env::temp_dir;
+use std::path::PathBuf;
+use std::ffi::AsOsStr;
 
 use inotify::INotify;
 use inotify::ffi::IN_MODIFY;
@@ -71,19 +73,20 @@ fn it_should_handle_file_names_correctly() {
 
 	let events = inotify.wait_for_events().unwrap();
 	assert!(events.len() > 0);
-	for event in events.iter() {
+	for event in events {
 		assert_eq!(file_name, event.name);
 	}
 }
 
 
-fn temp_file() -> (Path, File) {
-	let path = tmpdir().join("test-file");
+fn temp_file() -> (PathBuf, File) {
+	let path = temp_dir().join("test-file");
 	let file = File::create(&path).unwrap_or_else(|error|
 		panic!("Failed to create temporary file: {}", error)
 	);
+	let pathbuf = PathBuf::new(path.as_os_str());
 
-	(path, file)
+	(pathbuf, file)
 }
 
 fn write_to(file: &mut File) {


### PR DESCRIPTION
This updates for the changes to `std::path` added in  https://github.com/rust-lang/rust/pull/21759. (rfc: https://github.com/rust-lang/rfcs/blob/master/text/0474-path-reform.md) 

- Switches to using `unix::OsStrExt` (`path.as_os_str().as_byte_slice()`) for conversion from path to CString
- Switches to using `String::from_utf8()` (`String::from_utf8(c_str.as_bytes().to_vec())`) for conversion from CString to String
- Removes path feature, as it is no longer required