### PR TITLE
use the new std::io::{Error, Result}

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![crate_type = "lib"]
 #![warn(missing_docs)]
 #![stable]
-#![feature(collections, core, libc, io, os, std_misc)]
+#![feature(collections, core, libc, io, os, std_misc, path)]
 
 //! Binding and wrapper for inotify.
 //!

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -19,11 +19,6 @@ use std::ffi::{
     CString,
 };
 use std::mem;
-use std::old_io::{
-    EndOfFile,
-    IoError,
-    IoResult
-};
 use std::io;
 use std::os::errno;
 use std::os::unix::OsStrExt;
@@ -151,8 +146,8 @@ impl INotify {
                         .as_ptr()
                         .offset(event_size as isize);
 
-                    let mut name_slice = slice::from_raw_buf(
-                        &name_ptr,
+                    let mut name_slice = slice::from_raw_parts(
+                        name_ptr,
                         (*event).len as usize,
                     );
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -117,7 +117,11 @@ impl INotify {
 
         match len {
             0 => {
-                return Ok(&self.events[]);
+                return Err(
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "buffer passed to read() was too small to read event",
+                        None));
             }
             -1 => {
                 let error = errno();


### PR DESCRIPTION
So on line 123, there's no longer an `EndOfFile` variant of `ErrorKind`. The calls to `read` now return a `0` in the case of EOF (see [docs](http://doc.rust-lang.org/std/io/trait.Read.html#tymethod.read)). I wasn't sure what to do in the event of `0` in this case. I checked the man page and it said:

```
The behavior when the buffer given to read(2) is too small to return
       information about the next event depends on the kernel version: in
       kernels before 2.6.21, read(2) returns 0; since kernel 2.6.21,
       read(2) fails with the error EINVAL.  Specifying a buffer of size

           sizeof(struct inotify_event) + NAME_MAX + 1

       will be sufficient to read at least one event.
```

I'm not sure what an 'end of file' in the context of inotify is. Maybe we'll have to create our own enum variant to represent this. I return an empty slice for now.