### PR TITLE
to_cstring() returns a Result now

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -127,7 +127,7 @@ impl INotify {
             -1 => {
                 let error = errno();
                 if error == EAGAIN as i32 || error == EWOULDBLOCK as i32 {
-                    return Ok(&self.events[]);
+                    return Ok(&self.events[..]);
                 }
                 else {
                     return Err(io::Error::from_os_error(error));
@@ -183,7 +183,7 @@ impl INotify {
             }
         }
 
-        Ok(&self.events[])
+        Ok(&self.events[..])
     }
 
     pub fn close(&self) -> io::Result<()> {

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -59,9 +59,10 @@ impl INotify {
 
     pub fn add_watch(&self, path: &Path, mask: u32) -> io::Result<Watch> {
         let wd = unsafe {
+            let c_str = try!(path.as_os_str().to_cstring());
             ffi::inotify_add_watch(
                 self.fd,
-                path.as_os_str().to_cstring().as_ptr(),
+                c_str.as_ptr(),
                 mask
             )
         };
@@ -163,7 +164,7 @@ impl INotify {
                         None      => (),
                     }
 
-                    let c_str = CString::from_slice(name_slice);
+                    let c_str = try!(CString::new(name_slice));
 
                     match String::from_utf8(c_str.as_bytes().to_vec()) {
                         Ok(string)

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,12 +1,14 @@
 // This test suite is incomplete and doesn't cover all available functionality.
 // Contributions to improve test coverage would be highly appreciated!
 
-#![feature(io, env, path, std_misc)]
+#![feature(io, os, fs, env, path, old_path, std_misc)]
 
 extern crate inotify;
 
 
-use std::old_io::File;
+use std::fs::File;
+use std::io::Write;
+
 use std::env::temp_dir;
 use std::path::PathBuf;
 use std::ffi::AsOsStr;
@@ -63,7 +65,10 @@ fn it_should_not_return_duplicate_events() {
 #[test]
 fn it_should_handle_file_names_correctly() {
 	let (mut path, mut file) = temp_file();
-	let file_name = file.path().filename_str().unwrap().to_string();
+	let file_name = file.path().unwrap()
+        .file_name().unwrap()
+        .to_str().unwrap()
+        .to_string();
 	path.pop(); // Get path to the directory the file is in
 
 	let mut inotify = INotify::init().unwrap();
@@ -91,7 +96,7 @@ fn temp_file() -> (PathBuf, File) {
 
 fn write_to(file: &mut File) {
 	file
-		.write_line("This should trigger an inotify event.")
+		.write(b"This should trigger an inotify event.")
 		.unwrap_or_else(|error|
 			panic!("Failed to write to file: {}", error)
 		);


### PR DESCRIPTION
* `to_cstring()` returns a `Result` now, so compilation was failing
* `CString::from_slice()` is being deprecated, so I updated this to `CString::new()`
* Update syntax `[]` to `[..]`
* In the tests, use the new `File` and `Path`s. AFAICT, `temp_dir()` still returns an `old_path::Path`, and there isn't a newer `temp_dir()` method anywhere that returns a new `Path` yet.