### PR TITLE
OsStrExt has moved, update import path. Use cheaper travis servers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,5 @@
 language: rust
+
+# Run this build on the "container-based infrastructure"
+# See http://docs.travis-ci.com/user/workers/container-based-infrastructure/.
+sudo: false

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -21,7 +21,7 @@ use std::ffi::{
 use std::mem;
 use std::io;
 use std::os::errno;
-use std::os::unix::OsStrExt;
+use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use std::ffi::AsOsStr;
 use std::slice;


### PR DESCRIPTION
… cheaper in the sense that the main build servers are often overbooked, while the container-based build infrastructure mostly isn't (http://www.traviscistatus.com/).