### PR TITLE
Update to remove all usages of unstable features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: rust
 
+# Test using both the rust 1.0.0-beta, and the latest nightly
+rust:
+  - 1.0.0-beta
+  - nightly
+
 # Run this build on the "container-based infrastructure"
 # See http://docs.travis-ci.com/user/workers/container-based-infrastructure/.
 sudo: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ documentation = "https://github.com/hannobraun/inotify-rs/blob/master/README.md"
 homepage = "https://github.com/hannobraun/inotify-rs"
 repository = "https://github.com/hannobraun/inotify-rs"
 license = "ISC"
+
+[dependencies]
+libc = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 #![crate_type = "lib"]
 #![warn(missing_docs)]
 #![stable]
-#![feature(collections, convert, libc, std_misc)]
 
 //! Binding and wrapper for inotify.
 //!

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,8 +1,6 @@
 // This test suite is incomplete and doesn't cover all available functionality.
 // Contributions to improve test coverage would be highly appreciated!
 
-#![feature(file_path, std_misc)]
-
 extern crate inotify;
 
 
@@ -11,7 +9,6 @@ use std::io::Write;
 
 use std::env::temp_dir;
 use std::path::PathBuf;
-use std::ffi::AsOsStr;
 
 use inotify::INotify;
 use inotify::ffi::IN_MODIFY;
@@ -65,7 +62,7 @@ fn it_should_not_return_duplicate_events() {
 #[test]
 fn it_should_handle_file_names_correctly() {
 	let (mut path, mut file) = temp_file();
-	let file_name = file.path().unwrap()
+	let file_name = path
         .file_name().unwrap()
         .to_str().unwrap()
         .to_string();
@@ -89,7 +86,7 @@ fn temp_file() -> (PathBuf, File) {
 	let file = File::create(&path).unwrap_or_else(|error|
 		panic!("Failed to create temporary file: {}", error)
 	);
-	let path_buf = PathBuf::from(path.as_os_str());
+	let path_buf = PathBuf::from(path);
 
 	(path_buf, file)
 }


### PR DESCRIPTION
In `src`:
- Replaces dependency on in-rustc libc with the libc crate on crates.io
- Removes unrequired imports of `std::ffi::AsOsStr`, as Path implements a separate `.as_os_str()` method without the trait
- Replaces usage of `OsStr.to_cstring()` with `CString::new()`.
  - Note: this replaces a match statement with `try!()`
    - `io::Error` implements `From<NulError>`, so we can just use `try!()` instead of manually crafting an `io::Error`.
- Replaces usage of `slice.position_elem()` with `.splitn()`
  - This usage of `.nsplit(|b| b == &0u8).next().unwrap()` splits the slice on the first `\0` byte, taking everything before it, or just leaves it as it is if the slice doesn't have any `\0` bytes
    - Note: the `2` passed to `splitn()` ensures that `splitn` won't continue checking the string for more `\0` bytes after it has found one `\0` byte.
  - This exactly mirrors the behavior of the code it replaced, it just uses .split() instead of manually checking for the first instance of `\0` and splitting the slice manually.

In `tests`:
- Replaces usage of `file.path()` with just using the `PathBuf` produced by `temp_file()`.
  - As far as I can tell, both file.path() and the PathBuf produced should be exactly the same, as the `PathBuf` is literally taken from the exact file which was opened.
- Switches usage of `PathBuf::from(path.as_os_str())` to `PathBuf::from(path)`

This also updates `.travis.yml` to build and test with both the 1.0.0 beta build, and the latest nightly (instead of just the latest nightly).