### PR TITLE
removed stability attributes

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,5 +1,3 @@
-#![stable]
-
 //! Bindings for inotify
 //!
 //! There are four types of statics:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![crate_name = "inotify"]
 #![crate_type = "lib"]
 #![warn(missing_docs)]
-#![stable]
 
 //! Binding and wrapper for inotify.
 //!

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,4 +1,3 @@
-#![unstable]
 #![allow(missing_docs)]
 
 //! Idiomatic wrapper for inotify


### PR DESCRIPTION
A recent Rust nightly update removed the #[stable], #[unstable] and #[deprecated] attributes for non-#[staged_api] crates (rust-lang/rust#22830) in favor of a more complex release system ([RFC](https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md)).

Stability attributes are now bound to features, mainly intended for Rusts own release cycle. I suggest removing the previously used stability attributes since inotify is already stable enough and not frequently changing as if it would benefit much from it.