### PR TITLE
Allow asynchronous closing.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,7 @@ license = "ISC"
 
 [dependencies]
 libc = "*"
+epoll = "*"
+
+[dev-dependencies]
+tempdir = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
 //! [wiki]: https://en.wikipedia.org/wiki/Inotify
 //! [inotify7]: http://man7.org/linux/man-pages/man7/inotify.7.html
 
+extern crate epoll;
 extern crate libc;
 
 pub use wrapper::INotify;

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -314,7 +314,7 @@ impl Drop for INotify {
 
 impl INotifyCloser {
     pub fn close_async(&self) {
-        if state == INotifyState::Open {
+        if self.state() == INotifyState::Open {
             self.state.store(CLOSING, Ordering::Relaxed);
         }
     }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -3,7 +3,8 @@
 //! Idiomatic wrapper for inotify
 
 use epoll::{self, EpollEvent};
-use epoll::util::{ctl_op as EpollControlOp, event_type as EpollEventType};
+use epoll::util::ctl_op as EpollControlOp;
+use epoll::util::event_type as EpollEventType;
 use libc::{
     F_GETFL,
     F_SETFL,

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -150,7 +150,7 @@ impl TestDir {
         let id = self.counter;
         self.counter += 1;
 
-        let path = self.dir.path().join("file-".to_owned() + &id.to_string());
+        let path = self.dir.path().join("file-".to_string() + &id.to_string());
         let file = File::create(&path)
             .unwrap_or_else(|error| panic!("Failed to create temporary file: {}", error));
 


### PR DESCRIPTION
Alright, I'm by no means done, but I thought I'd give you a chance to weigh in earlier, rather than later.

**Changes**
 - `INotify` is no longer cloneable. Therefore the API is essentially single-threaded, enforced by ownership semantics.
 - A new method `closer()` is introduced. Its return value enables asynchronous closing of the inotify fd.
   - To avoid any races, the actual closing is still done by whoever owns the corresponding `INotify`.
   - This only happens when `wait_for_events()` is called.
   - To allow `wait_for_events()` to react to asynchronous closing, it spins in an epoll loop with a smallish timeout.

**TODO**
 - [ ] Look at `available_events()` wrt asynchronous closing. Currently it does not make sense, because the caller can't determine if the inotify fd was closed without calling a blocking method. Maybe expose the state?
 - [ ] Figure out a good epoll timeout (10ms seems a bit high).
 - [x] Go over all the `unwrap()` calls and figure out how to deal with the potential error conditions.
 - [ ] More tests
 - [ ] Documentation

(ref #28)