### PR TITLE
INotify is no longer cloneable.

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -27,7 +27,6 @@ use ffi::inotify_event;
 
 pub type Watch = c_int;
 
-#[derive(Clone)]
 pub struct INotify {
     pub fd: c_int,
     events: Vec<Event>,


### PR DESCRIPTION
The ability to clone `INotify` enabled races (see #28 and #29).