### PR TITLE
Fixed sporadic test failure.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ license = "ISC"
 
 [dependencies]
 libc = "*"
+
+[dev-dependencies]
+tempdir = "*"

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -2,21 +2,20 @@
 // Contributions to improve test coverage would be highly appreciated!
 
 extern crate inotify;
-
-
-use std::fs::File;
-use std::io::Write;
-
-use std::env::temp_dir;
-use std::path::PathBuf;
+extern crate tempdir;
 
 use inotify::INotify;
 use inotify::ffi::IN_MODIFY;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+use tempdir::TempDir;
 
 
 #[test]
 fn it_should_watch_a_file() {
-	let (path, mut file) = temp_file();
+    let mut testdir = TestDir::new();
+    let (path, mut file) = testdir.new_file();
 
 	let mut inotify = INotify::init().unwrap();
 	let watch = inotify.add_watch(&path, IN_MODIFY).unwrap();
@@ -39,16 +38,8 @@ fn it_should_return_immediately_if_no_events_are_available() {
 
 #[test]
 fn it_should_not_return_duplicate_events() {
-	// Usually, the write in this test seems to generate only one event, but
-	// sometimes it generates multiple events. If that happens, the assertion at
-	// the end will likely fail.
-	//
-	// I'm not sure why that happens, and since the test works as intended most
-	// of the time, I don't think it's that big of a deal. If you happen to know
-	// more about the subject, please consider to fix the test accordingly. It
-	// would be greatly appreciated!
-
-	let (path, mut file) = temp_file();
+    let mut testdir = TestDir::new();
+    let (path, mut file) = testdir.new_file();
 
 	let mut inotify = INotify::init().unwrap();
 	inotify.add_watch(&path, IN_MODIFY).unwrap();
@@ -61,7 +52,8 @@ fn it_should_not_return_duplicate_events() {
 
 #[test]
 fn it_should_handle_file_names_correctly() {
-	let (mut path, mut file) = temp_file();
+    let mut testdir = TestDir::new();
+    let (mut path, mut file) = testdir.new_file();
 	let file_name = path
         .file_name().unwrap()
         .to_str().unwrap()
@@ -81,14 +73,29 @@ fn it_should_handle_file_names_correctly() {
 }
 
 
-fn temp_file() -> (PathBuf, File) {
-	let path = temp_dir().join("test-file");
-	let file = File::create(&path).unwrap_or_else(|error|
-		panic!("Failed to create temporary file: {}", error)
-	);
-	let path_buf = PathBuf::from(path);
+struct TestDir {
+    dir: TempDir,
+    counter: u32,
+}
 
-	(path_buf, file)
+impl TestDir {
+    fn new() -> TestDir {
+        TestDir {
+            dir: TempDir::new("inotify-rs-test").unwrap(),
+            counter: 0,
+        }
+    }
+
+    fn new_file(&mut self) -> (PathBuf, File) {
+        let id = self.counter;
+        self.counter += 1;
+
+        let path = self.dir.path().join("file-".to_string() + &id.to_string());
+        let file = File::create(&path)
+            .unwrap_or_else(|error| panic!("Failed to create temporary file: {}", error));
+
+        (path, file)
+    }
 }
 
 fn write_to(file: &mut File) {


### PR DESCRIPTION
Cargo runs tests in parallel. A dev-dependency on [tempdir][1] was added to cleanly separate tests. This fixes the sporadic failure of `it_should_not_return_duplicate_events` when other tests interfered with it.

[1]: https://github.com/rust-lang-nursery/tempdir