### PR TITLE
Some updates from using in a project - more Path use

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -37,8 +37,8 @@ impl INotify {
         INotify::init_with_flags(0)
     }
 
-    pub fn init_with_flags(flags: isize) -> io::Result<INotify> {
-        let fd = unsafe { ffi::inotify_init1(flags as c_int) };
+    pub fn init_with_flags(flags: c_int) -> io::Result<INotify> {
+        let fd = unsafe { ffi::inotify_init1(flags) };
 
         unsafe { fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK) };
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -34,13 +34,12 @@ pub struct INotify {
 
 impl INotify {
     pub fn init() -> io::Result<INotify> {
-        INotify::init_with_flags(0)
+        INotify::init_with_flags(ffi::IN_CLOEXEC)
     }
 
     pub fn init_with_flags(flags: c_int) -> io::Result<INotify> {
+        let flags = flags | ffi::IN_NONBLOCK;
         let fd = unsafe { ffi::inotify_init1(flags) };
-
-        unsafe { fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK) };
 
         match fd {
             -1 => Err(io::Error::last_os_error()),

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -173,11 +173,20 @@ impl INotify {
         Ok(&self.events[..])
     }
 
-    pub fn close(self) -> io::Result<()> {
+    pub fn close(mut self) -> io::Result<()> {
         let result = unsafe { ffi::close(self.fd) };
+        self.fd = -1;
         match result {
             0 => Ok(()),
             _ => Err(io::Error::last_os_error())
+        }
+    }
+}
+
+impl Drop for INotify {
+    fn drop(&mut self) {
+        if self.fd != -1 {
+            unsafe { ffi::close(self.fd); }
         }
     }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -68,7 +68,7 @@ fn it_should_handle_file_names_correctly() {
 	let events = inotify.wait_for_events().unwrap();
 	assert!(events.len() > 0);
 	for event in events {
-		assert_eq!(file_name, event.name);
+		assert_eq!(file_name, event.name.to_str().unwrap());
 	}
 }
 


### PR DESCRIPTION
I'm using inotify to replace/augment an fs::read_dir loop, so having Path objects as the common interface made more sense. I also made some other minor API changes that should make it nicer for users; none of these commits depend on one another, so take one or all.