### PR TITLE
add: Hash trait for WatchDescriptor

### DIFF
--- a/inotify/src/lib.rs
+++ b/inotify/src/lib.rs
@@ -557,7 +557,7 @@ pub use self::watch_mask::WatchMask;
 /// [`Inotify::add_watch`]: struct.Inotify.html#method.add_watch
 /// [`Inotify::rm_watch`]: struct.Inotify.html#method.rm_watch
 /// [`Event`]: struct.Event.html
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct WatchDescriptor(RawFd);
 
 


### PR DESCRIPTION
I've made a new PR after breaking the previous one due to a clunky rebase/squash.

I've added the `Hash` to the `WatchDescriptor` struct, to allow it to be used for `HashMap` lookup.