### PR TITLE
bugfix: inotify-rs issue #59: using libc::c_int instead of RawFd for …

### DIFF
--- a/inotify/src/lib.rs
+++ b/inotify/src/lib.rs
@@ -45,6 +45,7 @@ use libc::{
     fcntl,
     c_void,
     size_t,
+    c_int,
 };
 
 
@@ -558,7 +559,7 @@ pub use self::watch_mask::WatchMask;
 /// [`Inotify::rm_watch`]: struct.Inotify.html#method.rm_watch
 /// [`Event`]: struct.Event.html
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub struct WatchDescriptor(RawFd);
+pub struct WatchDescriptor(c_int);
 
 
 /// Iterates over inotify events


### PR DESCRIPTION
…WatchDescriptors

Fixes Issue #59 

changed WatchDescriptor(RawFd) to WatchDescriptor(c_int) and added import for clib::c_int