### PR TITLE
Add infrastructure for automatic releases

### DIFF
--- a/inotify-sys/Cargo.toml
+++ b/inotify-sys/Cargo.toml
@@ -17,3 +17,8 @@ travis-ci = { repository = "hannobraun/inotify-rs" }
 
 [dependencies]
 libc = "0.2"
+
+[package.metadata.release]
+pre-release-commit-message = "Release inotify-sys {{version}}"
+pro-release-commit-message = "Bump inotify-sys version to {{version}}"
+tag-message                = "inotify-sys version {{version}}"

--- a/inotify/Cargo.toml
+++ b/inotify/Cargo.toml
@@ -28,3 +28,8 @@ libc        = "0.2"
 
 [dev-dependencies]
 tempdir = "0.3"
+
+[package.metadata.release]
+pre-release-commit-message = "Release inotify {{version}}"
+pro-release-commit-message = "Bump inotify version to {{version}}"
+tag-message                = "inotify version {{version}}"

--- a/release
+++ b/release
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+if [ $# -ne 2 ]
+then
+	echo "Usage: $(basename $0) <crate> <level>"
+	exit 1
+fi
+
+CRATE=$1
+LEVEL=$2
+
+cd $CRATE
+
+BOLD=$(tput bold)
+NORMAL=$(tput sgr0)
+
+function release {
+	cargo release -l $1 --tag-prefix ${2}_v $3
+}
+
+echo
+echo "${BOLD}Starting cargo release dry run...${NORMAL}"
+echo
+
+release $LEVEL $CRATE --dry-run
+
+# cargo-release requires its own confirmation, so we don't have to build one
+# into this script.
+release $LEVEL $CRATE


### PR DESCRIPTION
Since cargo-release won't let me release anything as long as there are uncommitted changes, I wasn't able to test this. The dry run looks good though, so I'm hopeful I won't have to adjust this later.