### PR TITLE
Adjust .gitignore to ignore all Cargo.lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/Cargo.lock
+Cargo.lock
 /**/target
 *.sublime-workspace
 *.swp


### PR DESCRIPTION
Previously, it was just ignoring the one in the repository root.

This shouldn't make any difference, as there shouldn't be any other
Cargo.lock files, but I need this to work around [a bug in
cargo-release](https://github.com/sunng87/cargo-release/issues/34).