### PR TITLE
Fix WatchDescriptor equality in the presence of reused file descriptors

### DIFF
--- a/inotify/src/lib.rs
+++ b/inotify/src/lib.rs
@@ -605,7 +605,7 @@ pub use self::watch_mask::WatchMask;
 /// [`Inotify::add_watch`]: struct.Inotify.html#method.add_watch
 /// [`Inotify::rm_watch`]: struct.Inotify.html#method.rm_watch
 /// [`Event`]: struct.Event.html
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct WatchDescriptor{
     id: c_int,
     fd: RawFd,

--- a/inotify/src/lib.rs
+++ b/inotify/src/lib.rs
@@ -327,14 +327,12 @@ impl Inotify {
     pub fn read_events_blocking<'a>(&mut self, buffer: &'a mut [u8])
         -> io::Result<Events<'a>>
     {
-        let fd = self.fd;
-
         unsafe {
-            fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) & !O_NONBLOCK)
+            fcntl(self.fd, F_SETFL, fcntl(self.fd, F_GETFL) & !O_NONBLOCK)
         };
         let result = self.read_events(buffer);
         unsafe {
-            fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK)
+            fcntl(self.fd, F_SETFL, fcntl(self.fd, F_GETFL) | O_NONBLOCK)
         };
 
         result

--- a/inotify/src/lib.rs
+++ b/inotify/src/lib.rs
@@ -29,6 +29,10 @@ extern crate inotify_sys as ffi;
 
 
 use std::mem;
+use std::hash::{
+    Hash,
+    Hasher,
+};
 use std::io;
 use std::io::ErrorKind;
 use std::os::unix::ffi::OsStrExt;
@@ -605,11 +609,27 @@ pub use self::watch_mask::WatchMask;
 /// [`Inotify::add_watch`]: struct.Inotify.html#method.add_watch
 /// [`Inotify::rm_watch`]: struct.Inotify.html#method.rm_watch
 /// [`Event`]: struct.Event.html
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug)]
 pub struct WatchDescriptor{
     id: c_int,
     fd: RawFd,
 }
+
+impl Eq for WatchDescriptor {}
+
+impl PartialEq for WatchDescriptor {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id && self.fd == other.fd
+    }
+}
+
+impl Hash for WatchDescriptor {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+        self.fd.hash(state);
+    }
+}
+
 
 /// Iterates over inotify events
 ///

--- a/inotify/tests/main.rs
+++ b/inotify/tests/main.rs
@@ -16,6 +16,10 @@ use std::io::{
     Write,
     ErrorKind,
 };
+use std::os::unix::io::{
+    FromRawFd,
+    IntoRawFd,
+};
 use std::path::PathBuf;
 use tempdir::TempDir;
 
@@ -131,12 +135,6 @@ fn watch_descriptors_from_different_inotify_instances_should_not_be_equal() {
 
 #[test]
 fn it_should_implement_raw_fd_traits_correctly() {
-    use std::os::unix::io::{
-        FromRawFd,
-        IntoRawFd,
-    };
-
-
     let fd = Inotify::init()
         .expect("Failed to initialize inotify instance")
         .into_raw_fd();


### PR DESCRIPTION
This pull request fixes the issue [described in #60](https://github.com/hannobraun/inotify-rs/issues/60#issuecomment-323503778). It also sneaks in a fix related to the interaction of `Inotify::close` and `Inotify`'s `Drop` implementation, as I had to touch that code anyway.