### PR TITLE
Clarify that Event may have a name for indirectly-watched directories.

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -98,7 +98,7 @@ pub struct Event<S> {
 
     /// The name of the file the event originates from
     ///
-    /// This field is set only if the subject of the event is a file in a
+    /// This field is set only if the subject of the event is a file or directory in a
     /// watched directory. If the event concerns a file or directory that is
     /// watched directly, `name` will be `None`.
     pub name: Option<S>,


### PR DESCRIPTION
Clarify that events will populate the Name field when the Event is in a watched directory but does not concern a file or directory that is watched directly. The previous documentation implied this only applied to files, but at least on 5.10.0-3 I'm finding that it applies to both files and directories, with the relevant point being only whether it is watched directly, and this behavior makes more sense anyway IMO.