### PR TITLE
Align input buffers before reading or writing inotify events

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -12,6 +12,7 @@ use inotify_sys as ffi;
 
 use crate::fd_guard::FdGuard;
 use crate::watches::WatchDescriptor;
+use crate::util::align_buffer;
 
 
 /// Iterator over inotify events
@@ -148,10 +149,18 @@ impl<'a> Event<&'a OsStr> {
         -> (usize, Self)
     {
         let event_size = mem::size_of::<ffi::inotify_event>();
+        let event_align = mem::align_of::<ffi::inotify_event>();
 
-        // Make sure that the buffer is big enough to contain an event, without
+        // Make sure that the buffer can satisfy the alignment requirements for `inotify_event`
+        assert!(buffer.len() >= event_align);
+
+        // Discard the unaligned portion, if any, of the supplied buffer
+        let buffer = align_buffer(buffer);
+
+        // Make sure that the aligned buffer is big enough to contain an event, without
         // the name. Otherwise we can't safely convert it to an `inotify_event`.
         assert!(buffer.len() >= event_size);
+
 
         let event = buffer.as_ptr() as *const ffi::inotify_event;
 
@@ -390,6 +399,8 @@ mod tests {
         sync,
     };
 
+    use crate::util;
+
     use inotify_sys as ffi;
 
     use super::Event;
@@ -398,6 +409,9 @@ mod tests {
     #[test]
     fn from_buffer_should_not_mistake_next_event_for_name_of_previous_event() {
         let mut buffer = [0u8; 1024];
+
+        // Make sure the buffer is properly aligned before writing raw events into it
+        let buffer = util::align_buffer_mut(&mut buffer);
 
         // First, put a normal event into the buffer
         let event = ffi::inotify_event {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,7 @@
-use std::os::unix::io::RawFd;
+use std::{
+    mem,
+    os::unix::io::RawFd
+};
 
 use inotify_sys as ffi;
 use libc::{
@@ -9,10 +12,39 @@ use libc::{
 
 pub fn read_into_buffer(fd: RawFd, buffer: &mut [u8]) -> isize {
     unsafe {
+        // Discard the unaligned portion, if any, of the supplied buffer
+        let buffer = align_buffer_mut(buffer);
+
         ffi::read(
             fd,
             buffer.as_mut_ptr() as *mut c_void,
             buffer.len() as size_t
         )
     }
+}
+
+pub fn align_buffer(buffer: &[u8]) -> &[u8] {
+    if buffer.len() >= mem::align_of::<ffi::inotify_event>() {
+        unsafe {
+            let ptr = buffer.as_ptr();
+            let offset = ptr.align_offset(mem::align_of::<ffi::inotify_event>());
+            let aligned_ptr = ptr.add(offset);
+            std::slice::from_raw_parts(aligned_ptr, buffer.len() - offset)
+        }
+    } else {
+        &buffer[0..0]
+    }
+}
+
+pub fn align_buffer_mut(buffer: &mut [u8]) -> &mut [u8] {
+   if buffer.len() >= mem::align_of::<ffi::inotify_event>() {
+       unsafe {
+            let ptr = buffer.as_mut_ptr();
+            let offset = ptr.align_offset(mem::align_of::<ffi::inotify_event>());
+            let aligned_ptr = ptr.add(offset);
+            std::slice::from_raw_parts_mut(aligned_ptr, buffer.len() - offset)
+       }
+   } else {
+       &mut buffer[0..0]
+   } 
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -25,12 +25,9 @@ pub fn read_into_buffer(fd: RawFd, buffer: &mut [u8]) -> isize {
 
 pub fn align_buffer(buffer: &[u8]) -> &[u8] {
     if buffer.len() >= mem::align_of::<ffi::inotify_event>() {
-        unsafe {
-            let ptr = buffer.as_ptr();
-            let offset = ptr.align_offset(mem::align_of::<ffi::inotify_event>());
-            let aligned_ptr = ptr.add(offset);
-            std::slice::from_raw_parts(aligned_ptr, buffer.len() - offset)
-        }
+        let ptr = buffer.as_ptr();
+        let offset = ptr.align_offset(mem::align_of::<ffi::inotify_event>());
+        &buffer[offset..]
     } else {
         &buffer[0..0]
     }
@@ -38,12 +35,9 @@ pub fn align_buffer(buffer: &[u8]) -> &[u8] {
 
 pub fn align_buffer_mut(buffer: &mut [u8]) -> &mut [u8] {
    if buffer.len() >= mem::align_of::<ffi::inotify_event>() {
-       unsafe {
-            let ptr = buffer.as_mut_ptr();
-            let offset = ptr.align_offset(mem::align_of::<ffi::inotify_event>());
-            let aligned_ptr = ptr.add(offset);
-            std::slice::from_raw_parts_mut(aligned_ptr, buffer.len() - offset)
-       }
+        let ptr = buffer.as_mut_ptr();
+        let offset = ptr.align_offset(mem::align_of::<ffi::inotify_event>());
+        &mut buffer[offset..]
    } else {
        &mut buffer[0..0]
    } 


### PR DESCRIPTION
Attempts to solve #155

This passes the current tests and eliminates the `miri` warning about unaligned references that currently triggers [here](https://github.com/hannobraun/inotify/blob/b3a7062a732851ac39dfd63ba2bd337dbcff123e/src/events.rs#L156-L162), but I'm not certain if it's fully robust. The alignment code works by splitting away any unaligned portion of the input buffer, and so I'm not sure if the byte-tracking code in `Stream` and other places needs to be updated to reflect that.