### PR TITLE
Make `Event::into_owned` always available

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -206,7 +206,7 @@ impl<'a> Event<&'a OsStr> {
 
     /// Returns an owned copy of the event.
     #[must_use = "cloning is often expensive and is not expected to have side effects"]
-    pub(crate) fn into_owned(&self) -> EventOwned {
+    pub fn into_owned(&self) -> EventOwned {
         Event {
             wd: self.wd.clone(),
             mask: self.mask,

--- a/src/events.rs
+++ b/src/events.rs
@@ -204,7 +204,8 @@ impl<'a> Event<&'a OsStr> {
         (bytes_consumed, event)
     }
 
-    #[cfg(feature = "stream")]
+    /// Returns an owned copy of the event.
+    #[must_use = "cloning is often expensive and is not expected to have side effects"]
     pub(crate) fn into_owned(&self) -> EventOwned {
         Event {
             wd: self.wd.clone(),


### PR DESCRIPTION
This allows `Event::into_owned` to be used independent of the `stream` feature being enabled. Only a partial resolution to #178 since a future rust version will be needed to implement `ToOwned` since `Event` is Clone