### PR TITLE
Enable `deny(missing_debug_implementations)` and implement missing debug

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -22,6 +22,7 @@ use crate::util::align_buffer;
 ///
 /// [`Inotify::read_events_blocking`]: struct.Inotify.html#method.read_events_blocking
 /// [`Inotify::read_events`]: struct.Inotify.html#method.read_events
+#[derive(Debug)]
 pub struct Events<'a> {
     fd       : Weak<FdGuard>,
     buffer   : &'a [u8],

--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -48,6 +48,7 @@ use crate::stream::EventStream;
 /// usage example.
 ///
 /// [top-level documentation]: index.html
+#[derive(Debug)]
 pub struct Inotify {
     fd: Arc<FdGuard>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@
 
 #![deny(missing_docs)]
 #![deny(warnings)]
+#![deny(missing_debug_implementations)]
 
 
 #[macro_use]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -18,6 +18,7 @@ use crate::util::read_into_buffer;
 /// Allows for streaming events returned by [`Inotify::event_stream`].
 ///
 /// [`Inotify::event_stream`]: struct.Inotify.html#method.event_stream
+#[derive(Debug)]
 pub struct EventStream<T> {
     fd: AsyncFd<ArcFdGuard>,
     buffer: T,
@@ -77,6 +78,7 @@ where
 }
 
 // Newtype wrapper because AsRawFd isn't implemented for Arc<T> where T: AsRawFd.
+#[derive(Debug)]
 struct ArcFdGuard(Arc<FdGuard>);
 
 impl AsRawFd for ArcFdGuard {


### PR DESCRIPTION
Finishes up the missing debug implementations and enables the lint so no future missing debug implementations exist.