### PR TITLE
Add Ord/PartialOrd instances to WatchDescriptor

### DIFF
--- a/src/watches.rs
+++ b/src/watches.rs
@@ -3,6 +3,7 @@ use std::{
         Hash,
         Hasher,
     },
+    cmp::Ordering,
     os::raw::c_int,
     sync::Weak,
 };
@@ -297,6 +298,18 @@ impl PartialEq for WatchDescriptor {
         let other_fd = other.fd.upgrade();
 
         self.id == other.id && self_fd.is_some() && self_fd == other_fd
+    }
+}
+
+impl Ord for WatchDescriptor {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.id.cmp(&other.id)
+    }
+}
+
+impl PartialOrd for WatchDescriptor {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
As inotify watch descriptors don't have an order per se, an alternative would be to make the `id` field public outside of the crate, so users of this library can implement a wrapper that implements traits based on `id`. Otherwise some data structures can't use a `WatchDescriptor` as a key which can be useful (i.e. `BTreeMap<WatchDescriptor, PathBuf>`). 