### PR TITLE
Increase the buffer size for the stream example

### DIFF
--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), io::Error> {
         }
     });
 
-    let mut buffer = [0; 32];
+    let mut buffer = [0; 1024];
     let mut stream = inotify.event_stream(&mut buffer)?;
 
     while let Some(event_or_error) = stream.next().await {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,10 @@ pub use crate::events::{
     Events,
 };
 pub use crate::inotify::Inotify;
+pub use crate::util::{
+    get_buffer_size,
+    get_absolute_path_buffer_size,
+};
 pub use crate::watches::{
     WatchDescriptor,
     WatchMask,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,8 @@
 use std::{
+    io,
     mem,
-    os::unix::io::RawFd
+    os::unix::io::RawFd,
+    path::Path,
 };
 
 use inotify_sys as ffi;
@@ -9,6 +11,7 @@ use libc::{
     size_t,
 };
 
+const INOTIFY_EVENT_SIZE: usize = mem::size_of::<ffi::inotify_event>() + 257;
 
 pub fn read_into_buffer(fd: RawFd, buffer: &mut [u8]) -> isize {
     unsafe {
@@ -40,5 +43,53 @@ pub fn align_buffer_mut(buffer: &mut [u8]) -> &mut [u8] {
         &mut buffer[offset..]
    } else {
        &mut buffer[0..0]
-   } 
+   }
+}
+
+/// Get the inotify event buffer size
+///
+/// The maximum size of an inotify event and thus the buffer size to hold it
+/// can be calculated using this formula:
+/// `sizeof(struct inotify_event) + NAME_MAX + 1`
+///
+/// See: [https://man7.org/linux/man-pages/man7/inotify.7.html](https://man7.org/linux/man-pages/man7/inotify.7.html)
+///
+/// The NAME_MAX size formula is:
+/// `ABSOLUTE_PARENT_PATH_LEN + 1 + 255`
+///
+/// - `ABSOLUTE_PARENT_PATH_LEN` will be calculated at runtime.
+/// - Add 1 to account for a `/`, either in between the parent path and a filename
+/// or for the root directory.
+/// - Add the maximum number of chars in a filename, 255.
+///
+/// See: [https://github.com/torvalds/linux/blob/master/include/uapi/linux/limits.h](https://github.com/torvalds/linux/blob/master/include/uapi/linux/limits.h)
+///
+/// Unfortunately, we can't just do the same with max path length itself.
+///
+/// See: [https://eklitzke.org/path-max-is-tricky](https://eklitzke.org/path-max-is-tricky)
+///
+/// This function is really just a fallible wrapper around `get_absolute_path_buffer_size()`.
+///
+/// path: A relative or absolute path for the inotify events.
+#[allow(dead_code)]
+pub fn get_buffer_size(path: &Path) -> io::Result<usize> {
+    Ok(get_absolute_path_buffer_size(&path.canonicalize()?))
+}
+
+/// Get the inotify event buffer size for an absolute path
+///
+/// For relative paths, consider using `get_buffer_size()` which provides a fallible wrapper
+/// for this function.
+///
+/// path: An absolute path for the inotify events.
+#[allow(dead_code)]
+pub fn get_absolute_path_buffer_size(path: &Path) -> usize {
+    INOTIFY_EVENT_SIZE
+    // Get the length of the absolute parent path, if the path is not the root directory.
+    // Because we canonicalize the path, we do not need to worry about prefixes.
+    + if let Some(parent_path) = path.parent() {
+        parent_path.as_os_str().len()
+    } else {
+        0
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -71,7 +71,6 @@ pub fn align_buffer_mut(buffer: &mut [u8]) -> &mut [u8] {
 /// This function is really just a fallible wrapper around `get_absolute_path_buffer_size()`.
 ///
 /// path: A relative or absolute path for the inotify events.
-#[allow(dead_code)]
 pub fn get_buffer_size(path: &Path) -> io::Result<usize> {
     Ok(get_absolute_path_buffer_size(&path.canonicalize()?))
 }
@@ -82,7 +81,6 @@ pub fn get_buffer_size(path: &Path) -> io::Result<usize> {
 /// for this function.
 ///
 /// path: An absolute path for the inotify events.
-#[allow(dead_code)]
 pub fn get_absolute_path_buffer_size(path: &Path) -> usize {
     INOTIFY_EVENT_SIZE
     // Get the length of the absolute parent path, if the path is not the root directory.


### PR DESCRIPTION
This pull request increases the inotify event buffer size for the stream example from `32` to `1024` as discussed in Issue https://github.com/hannobraun/inotify-rs/issues/186.

Also included are two utility functions, `get_buffer_size()` and `get_absolute_path_buffer_size()`. The former is just a light, fallible wrapper around the latter. `get_buffer_size()` is meant to work with both relative and absolute paths, as it handles the canonicalization of the path. `get_absolute_path_buffer_size()` expects an absolute path to be passed in, and it is only meant to be used when a path is known to be absolute.

edit by @hannobraun:
Close #186 
(this should close the issue automatically when this is merged, so we don't forget)