### PR TITLE
Distinguish events from files with the same name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ libc         = "0.2"
 tokio        = { version = "1.0.1", optional = true, features = ["net"] }
 
 [dev-dependencies]
+maplit = "1.0"
+rand = "0.8"
 tempfile     = "3.1.0"
 futures-util = "0.3.1"
 tokio        = { version = "1.0.1", features = ["macros", "rt-multi-thread"] }

--- a/src/watches.rs
+++ b/src/watches.rs
@@ -19,7 +19,6 @@ use inotify_sys as ffi;
 
 use crate::fd_guard::FdGuard;
 
-
 bitflags! {
     /// Describes a file system watch
     ///
@@ -281,6 +280,14 @@ bitflags! {
     }
 }
 
+impl WatchDescriptor {
+    /// Getter method for a watcher's id.
+    ///
+    /// Can be used to distinguish events for files with the same name.
+    pub fn get_watch_descriptor_id(&self) -> c_int {
+        self.id
+    }
+}
 
 /// Interface for adding and removing watches
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Describe the issue

Hi! 

While using this API I found myself unable to distinguish between events that arrive from files with the same name yet in different paths. The problem can be formalised as below. 

---
Given two file watchers with the same file name but in different paths:

file watch 1: /tmp/file_a
file watch 2: /tmp/another_dir/file_a

And randomly triggering an event on one of the files. For which file was the event triggered? 

---

## Proposed changes

This PR proposes a getter method for the `WatchDescriptor`, allowing one the ability to store the id for a given file watch after an `.add_watch()` and using this to compare the `Event` struct coming from an event stream. 

--- 

As a side note, I am still learning Rust so if I used something where perhaps something else was better let me know and I am happy to make the changes! Also apologies for the auto-formatting on the files, I can revert them. Let me know! Thanks
