### PR TITLE
Add Clippy lints to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Install rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.47.0
+        toolchain: 1.49.0
         override: true
     - name: Check rust and cargo version
       run: rustc -V && cargo -V

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,13 +14,18 @@ jobs:
       with:
         toolchain: 1.49.0
         override: true
+        components: clippy
     - name: Check rust and cargo version
       run: rustc -V && cargo -V
     - name: Build
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Run Clippy lints
+      run: cargo clippy --verbose -- -D warnings
     - name: Build (no default features)
       run: cargo build --verbose --no-default-features
     - name: Run tests (no default features)
       run: cargo test --verbose --no-default-features
+    - name: Run Clippy lints (no default features)
+      run: cargo clippy --verbose --no-default-features -- -D warnings

--- a/src/events.rs
+++ b/src/events.rs
@@ -206,8 +206,15 @@ impl<'a> Event<&'a OsStr> {
     }
 
     /// Returns an owned copy of the event.
-    #[must_use = "cloning is often expensive and is not expected to have side effects"]
+    #[deprecated = "use `to_owned()` instead; methods named `into_owned()` usually take self by value"]
+    #[allow(clippy::wrong_self_convention)]
     pub fn into_owned(&self) -> EventOwned {
+        self.to_owned()
+    }
+
+    /// Returns an owned copy of the event.
+    #[must_use = "cloning is often expensive and is not expected to have side effects"]
+    pub fn to_owned(&self) -> EventOwned {
         Event {
             wd: self.wd.clone(),
             mask: self.mask,

--- a/src/events.rs
+++ b/src/events.rs
@@ -35,10 +35,10 @@ impl<'a> Events<'a> {
         -> Self
     {
         Events {
-            fd       : fd,
-            buffer   : buffer,
-            num_bytes: num_bytes,
-            pos      : 0,
+            fd,
+            buffer,
+            num_bytes,
+            pos: 0,
         }
     }
 }
@@ -118,7 +118,7 @@ impl<'a> Event<&'a OsStr> {
             fd,
         };
 
-        let name = if name == "" {
+        let name = if name.is_empty() {
             None
         }
         else {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -73,7 +73,7 @@ where
         self_.buffer_pos += bytes_consumed;
         self_.unused_bytes -= bytes_consumed;
 
-        Poll::Ready(Some(Ok(event.into_owned())))
+        Poll::Ready(Some(Ok(event.to_owned())))
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -34,7 +34,7 @@ where
     pub(crate) fn new(fd: Arc<FdGuard>, buffer: T) -> io::Result<Self> {
         Ok(EventStream {
             fd: AsyncFd::new(ArcFdGuard(fd))?,
-            buffer: buffer,
+            buffer,
             buffer_pos: 0,
             unused_bytes: 0,
         })


### PR DESCRIPTION
Fixes #181 

I also made an API deprecation, since Clippy was complaining about `Event.into_owned()` taking `&self` which is unexpected. `into_owned()` methods usually take `self` by value, not by reference. See https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention  
Resolution was to deprecate `into_owned()` and add the properly named method, `to_owned()`.  
This change may be relevant to #178 