### PR TITLE
Add Watches struct with add/remove methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ fn main() {
         .expect("Failed to determine current directory");
 
     inotify
-        .add_watch(
+        .watches()
+        .add(
             current_dir,
             WatchMask::MODIFY | WatchMask::CREATE | WatchMask::DELETE,
         )

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), io::Error> {
 
     let dir = TempDir::new()?;
 
-    inotify.add_watch(dir.path(), WatchMask::CREATE | WatchMask::MODIFY)?;
+    inotify.watches().add(dir.path(), WatchMask::CREATE | WatchMask::MODIFY)?;
 
     thread::spawn::<_, Result<(), io::Error>>(move || {
         loop {

--- a/examples/watch.rs
+++ b/examples/watch.rs
@@ -15,7 +15,8 @@ fn main() {
         .expect("Failed to determine current directory");
 
     inotify
-        .add_watch(
+        .watches()
+        .add(
             current_dir,
             WatchMask::MODIFY | WatchMask::CREATE | WatchMask::DELETE,
         )

--- a/src/events.rs
+++ b/src/events.rs
@@ -63,26 +63,26 @@ impl<'a> Iterator for Events<'a> {
 /// An inotify event
 ///
 /// A file system event that describes a change that the user previously
-/// registered interest in. To watch for events, call [`Inotify::add_watch`]. To
+/// registered interest in. To watch for events, call [`Watches::add`]. To
 /// retrieve events, call [`Inotify::read_events_blocking`] or
 /// [`Inotify::read_events`].
 ///
-/// [`Inotify::add_watch`]: struct.Inotify.html#method.add_watch
+/// [`Watches::add`]: struct.Watches.html#method.add
 /// [`Inotify::read_events_blocking`]: struct.Inotify.html#method.read_events_blocking
 /// [`Inotify::read_events`]: struct.Inotify.html#method.read_events
 #[derive(Clone, Debug)]
 pub struct Event<S> {
     /// Identifies the watch this event originates from
     ///
-    /// This [`WatchDescriptor`] is equal to the one that [`Inotify::add_watch`]
+    /// This [`WatchDescriptor`] is equal to the one that [`Watches::add`]
     /// returned when interest for this event was registered. The
     /// [`WatchDescriptor`] can be used to remove the watch using
-    /// [`Inotify::rm_watch`], thereby preventing future events of this type
+    /// [`Watches::remove`], thereby preventing future events of this type
     /// from being created.
     ///
     /// [`WatchDescriptor`]: struct.WatchDescriptor.html
-    /// [`Inotify::add_watch`]: struct.Inotify.html#method.add_watch
-    /// [`Inotify::rm_watch`]: struct.Inotify.html#method.rm_watch
+    /// [`Watches::add`]: struct.Watches.html#method.add
+    /// [`Watches::remove`]: struct.Watches.html#method.remove
     pub wd: WatchDescriptor,
 
     /// Indicates what kind of event this is
@@ -357,7 +357,7 @@ bitflags! {
         /// Watch was removed
         ///
         /// This event will be generated, if the watch was removed explicitly
-        /// (via [`Inotify::rm_watch`]), or automatically (because the file was
+        /// (via [`Watches::remove`]), or automatically (because the file was
         /// deleted or the file system was unmounted).
         ///
         /// See [`inotify_sys::IN_IGNORED`].

--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -120,76 +120,17 @@ impl Inotify {
         })
     }
 
-    /// Gets an interface that allows adding and removing watches
+    /// Gets an interface that allows adding and removing watches.
+    /// See [`Watches::add`] and [`Watches::remove`].
+    ///
+    /// [`Watches::add`]: struct.Watches.html#method.add
+    /// [`Watches::remove`]: struct.Watches.html#method.remove
     pub fn watches(&self) -> Watches {
         Watches::new(self.fd.clone())
     }
 
-    /// Adds or updates a watch for the given path
-    ///
-    /// Adds a new watch or updates an existing one for the file referred to by
-    /// `path`. Returns a watch descriptor that can be used to refer to this
-    /// watch later.
-    ///
-    /// The `mask` argument defines what kind of changes the file should be
-    /// watched for, and how to do that. See the documentation of [`WatchMask`]
-    /// for details.
-    ///
-    /// If this method is used to add a new watch, a new [`WatchDescriptor`] is
-    /// returned. If it is used to update an existing watch, a
-    /// [`WatchDescriptor`] that equals the previously returned
-    /// [`WatchDescriptor`] for that watch is returned instead.
-    ///
-    /// Under the hood, this method just calls [`inotify_add_watch`] and does
-    /// some trivial translation between the types on the Rust side and the C
-    /// side.
-    ///
-    /// # Attention: Updating watches and hardlinks
-    ///
-    /// As mentioned above, this method can be used to update an existing watch.
-    /// This is usually done by calling this method with the same `path`
-    /// argument that it has been called with before. But less obviously, it can
-    /// also happen if the method is called with a different path that happens
-    /// to link to the same inode.
-    ///
-    /// You can detect this by keeping track of [`WatchDescriptor`]s and the
-    /// paths they have been returned for. If the same [`WatchDescriptor`] is
-    /// returned for a different path (and you haven't freed the
-    /// [`WatchDescriptor`] by removing the watch), you know you have two paths
-    /// pointing to the same inode, being watched by the same watch.
-    ///
-    /// # Errors
-    ///
-    /// Directly returns the error from the call to
-    /// [`inotify_add_watch`][`inotify_add_watch`] (translated into an
-    /// `io::Error`), without adding any error conditions of
-    /// its own.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use inotify::{
-    ///     Inotify,
-    ///     WatchMask,
-    /// };
-    ///
-    /// let mut inotify = Inotify::init()
-    ///     .expect("Failed to initialize an inotify instance");
-    ///
-    /// # // Create a temporary file, so `add_watch` won't return an error.
-    /// # use std::fs::File;
-    /// # File::create("/tmp/inotify-rs-test-file")
-    /// #     .expect("Failed to create test file");
-    /// #
-    /// inotify.add_watch("/tmp/inotify-rs-test-file", WatchMask::MODIFY)
-    ///     .expect("Failed to add file watch");
-    ///
-    /// // Handle events for the file here
-    /// ```
-    ///
-    /// [`inotify_add_watch`]: ../inotify_sys/fn.inotify_add_watch.html
-    /// [`WatchMask`]: struct.WatchMask.html
-    /// [`WatchDescriptor`]: struct.WatchDescriptor.html
+    /// Deprecated: use `Inotify.watches().add()` instead
+    #[deprecated = "use `Inotify.watches().add()` instead"]
     pub fn add_watch<P>(&mut self, path: P, mask: WatchMask)
         -> io::Result<WatchDescriptor>
         where P: AsRef<Path>
@@ -197,57 +138,8 @@ impl Inotify {
         self.watches().add(path, mask)
     }
 
-    /// Stops watching a file
-    ///
-    /// Removes the watch represented by the provided [`WatchDescriptor`] by
-    /// calling [`inotify_rm_watch`]. [`WatchDescriptor`]s can be obtained via
-    /// [`Inotify::add_watch`], or from the `wd` field of [`Event`].
-    ///
-    /// # Errors
-    ///
-    /// Directly returns the error from the call to [`inotify_rm_watch`].
-    /// Returns an [`io::Error`] with [`ErrorKind`]`::InvalidInput`, if the given
-    /// [`WatchDescriptor`] did not originate from this [`Inotify`] instance.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use inotify::Inotify;
-    ///
-    /// let mut inotify = Inotify::init()
-    ///     .expect("Failed to initialize an inotify instance");
-    ///
-    /// # // Create a temporary file, so `add_watch` won't return an error.
-    /// # use std::fs::File;
-    /// # let mut test_file = File::create("/tmp/inotify-rs-test-file")
-    /// #     .expect("Failed to create test file");
-    /// #
-    /// # // Add a watch and modify the file, so the code below doesn't block
-    /// # // forever.
-    /// # use inotify::WatchMask;
-    /// # inotify.add_watch("/tmp/inotify-rs-test-file", WatchMask::MODIFY)
-    /// #     .expect("Failed to add file watch");
-    /// # use std::io::Write;
-    /// # write!(&mut test_file, "something\n")
-    /// #     .expect("Failed to write something to test file");
-    /// #
-    /// let mut buffer = [0; 1024];
-    /// let events = inotify
-    ///     .read_events_blocking(&mut buffer)
-    ///     .expect("Error while waiting for events");
-    ///
-    /// for event in events {
-    ///     inotify.rm_watch(event.wd);
-    /// }
-    /// ```
-    ///
-    /// [`WatchDescriptor`]: struct.WatchDescriptor.html
-    /// [`inotify_rm_watch`]: ../inotify_sys/fn.inotify_rm_watch.html
-    /// [`Inotify::add_watch`]: struct.Inotify.html#method.add_watch
-    /// [`Event`]: struct.Event.html
-    /// [`Inotify`]: struct.Inotify.html
-    /// [`io::Error`]: https://doc.rust-lang.org/std/io/struct.Error.html
-    /// [`ErrorKind`]: https://doc.rust-lang.org/std/io/enum.ErrorKind.html
+    /// Deprecated: use `Inotify.watches().remove()` instead
+    #[deprecated = "use `Inotify.watches().remove()` instead"]
     pub fn rm_watch(&mut self, wd: WatchDescriptor) -> io::Result<()> {
         self.watches().remove(wd)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,14 +19,15 @@
 //! let mut inotify = Inotify::init()
 //!     .expect("Error while initializing inotify instance");
 //!
-//! # // Create a temporary file, so `add_watch` won't return an error.
+//! # // Create a temporary file, so `Watches::add` won't return an error.
 //! # use std::fs::File;
 //! # let mut test_file = File::create("/tmp/inotify-rs-test-file")
 //! #     .expect("Failed to create test file");
 //! #
 //! // Watch for modify and close events.
 //! inotify
-//!     .add_watch(
+//!     .watches()
+//!     .add(
 //!         "/tmp/inotify-rs-test-file",
 //!         WatchMask::MODIFY | WatchMask::CLOSE,
 //!     )
@@ -37,7 +38,7 @@
 //! # write!(&mut test_file, "something\n")
 //! #     .expect("Failed to write something to test file");
 //! #
-//! // Read events that were added with `add_watch` above.
+//! // Read events that were added with `Watches::add` above.
 //! let mut buffer = [0; 1024];
 //! let events = inotify.read_events_blocking(&mut buffer)
 //!     .expect("Error while reading events");

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -12,6 +12,7 @@ use tokio::io::unix::AsyncFd;
 use crate::events::{Event, EventOwned};
 use crate::fd_guard::FdGuard;
 use crate::util::read_into_buffer;
+use crate::watches::Watches;
 
 /// Stream of inotify events
 ///
@@ -38,6 +39,15 @@ where
             buffer_pos: 0,
             unused_bytes: 0,
         })
+    }
+
+    /// Returns an instance of `Watches` to add and remove watches.
+    /// See [`Watches::add`] and [`Watches::remove`].
+    ///
+    /// [`Watches::add`]: struct.Watches.html#method.add
+    /// [`Watches::remove`]: struct.Watches.html#method.remove
+    pub fn watches(&self) -> Watches {
+        Watches::new(self.fd.get_ref().0.clone())
     }
 }
 

--- a/src/watches.rs
+++ b/src/watches.rs
@@ -23,12 +23,12 @@ use crate::fd_guard::FdGuard;
 bitflags! {
     /// Describes a file system watch
     ///
-    /// Passed to [`Inotify::add_watch`], to describe what file system events
+    /// Passed to [`Watches::add`], to describe what file system events
     /// to watch for, and how to do that.
     ///
     /// # Examples
     ///
-    /// `WatchMask` constants can be passed to [`Inotify::add_watch`] as is. For
+    /// `WatchMask` constants can be passed to [`Watches::add`] as is. For
     /// example, here's how to create a watch that triggers an event when a file
     /// is accessed:
     ///
@@ -40,12 +40,12 @@ bitflags! {
     /// #
     /// # let mut inotify = Inotify::init().unwrap();
     /// #
-    /// # // Create a temporary file, so `add_watch` won't return an error.
+    /// # // Create a temporary file, so `Watches::add` won't return an error.
     /// # use std::fs::File;
     /// # File::create("/tmp/inotify-rs-test-file")
     /// #     .expect("Failed to create test file");
     /// #
-    /// inotify.add_watch("/tmp/inotify-rs-test-file", WatchMask::ACCESS)
+    /// inotify.watches().add("/tmp/inotify-rs-test-file", WatchMask::ACCESS)
     ///    .expect("Error adding watch");
     /// ```
     ///
@@ -59,11 +59,11 @@ bitflags! {
     /// # };
     /// #
     /// # let mut inotify = Inotify::init().unwrap();
-    /// inotify.add_watch("/tmp/", WatchMask::CREATE | WatchMask::DELETE)
+    /// inotify.watches().add("/tmp/", WatchMask::CREATE | WatchMask::DELETE)
     ///    .expect("Error adding watch");
     /// ```
     ///
-    /// [`Inotify::add_watch`]: struct.Inotify.html#method.add_watch
+    /// [`Watches::add`]: struct.Watches.html#method.add
     pub struct WatchMask: u32 {
         /// File was accessed
         ///
@@ -347,12 +347,12 @@ impl Watches {
     /// let mut inotify = Inotify::init()
     ///     .expect("Failed to initialize an inotify instance");
     ///
-    /// # // Create a temporary file, so `add_watch` won't return an error.
+    /// # // Create a temporary file, so `Watches::add` won't return an error.
     /// # use std::fs::File;
     /// # File::create("/tmp/inotify-rs-test-file")
     /// #     .expect("Failed to create test file");
     /// #
-    /// inotify.add_watch("/tmp/inotify-rs-test-file", WatchMask::MODIFY)
+    /// inotify.watches().add("/tmp/inotify-rs-test-file", WatchMask::MODIFY)
     ///     .expect("Failed to add file watch");
     ///
     /// // Handle events for the file here
@@ -385,7 +385,7 @@ impl Watches {
     ///
     /// Removes the watch represented by the provided [`WatchDescriptor`] by
     /// calling [`inotify_rm_watch`]. [`WatchDescriptor`]s can be obtained via
-    /// [`Inotify::add_watch`], or from the `wd` field of [`Event`].
+    /// [`Watches::add`], or from the `wd` field of [`Event`].
     ///
     /// # Errors
     ///
@@ -401,7 +401,7 @@ impl Watches {
     /// let mut inotify = Inotify::init()
     ///     .expect("Failed to initialize an inotify instance");
     ///
-    /// # // Create a temporary file, so `add_watch` won't return an error.
+    /// # // Create a temporary file, so `Watches::add` won't return an error.
     /// # use std::fs::File;
     /// # let mut test_file = File::create("/tmp/inotify-rs-test-file")
     /// #     .expect("Failed to create test file");
@@ -409,7 +409,7 @@ impl Watches {
     /// # // Add a watch and modify the file, so the code below doesn't block
     /// # // forever.
     /// # use inotify::WatchMask;
-    /// # inotify.add_watch("/tmp/inotify-rs-test-file", WatchMask::MODIFY)
+    /// # inotify.watches().add("/tmp/inotify-rs-test-file", WatchMask::MODIFY)
     /// #     .expect("Failed to add file watch");
     /// # use std::io::Write;
     /// # write!(&mut test_file, "something\n")
@@ -419,15 +419,16 @@ impl Watches {
     /// let events = inotify
     ///     .read_events_blocking(&mut buffer)
     ///     .expect("Error while waiting for events");
+    /// let mut watches = inotify.watches();
     ///
     /// for event in events {
-    ///     inotify.rm_watch(event.wd);
+    ///     watches.remove(event.wd);
     /// }
     /// ```
     ///
     /// [`WatchDescriptor`]: struct.WatchDescriptor.html
     /// [`inotify_rm_watch`]: ../inotify_sys/fn.inotify_rm_watch.html
-    /// [`Inotify::add_watch`]: struct.Inotify.html#method.add_watch
+    /// [`Watches::add`]: struct.Watches.html#method.add
     /// [`Event`]: struct.Event.html
     /// [`Inotify`]: struct.Inotify.html
     /// [`io::Error`]: https://doc.rust-lang.org/std/io/struct.Error.html
@@ -453,12 +454,12 @@ impl Watches {
 
 /// Represents a watch on an inode
 ///
-/// Can be obtained from [`Inotify::add_watch`] or from an [`Event`]. A watch
+/// Can be obtained from [`Watches::add`] or from an [`Event`]. A watch
 /// descriptor can be used to get inotify to stop watching an inode by passing
-/// it to [`Inotify::rm_watch`].
+/// it to [`Watches::remove`].
 ///
-/// [`Inotify::add_watch`]: struct.Inotify.html#method.add_watch
-/// [`Inotify::rm_watch`]: struct.Inotify.html#method.rm_watch
+/// [`Watches::add`]: struct.Watches.html#method.add
+/// [`Watches::remove`]: struct.Watches.html#method.remove
 /// [`Event`]: struct.Event.html
 #[derive(Clone, Debug)]
 pub struct WatchDescriptor{

--- a/src/watches.rs
+++ b/src/watches.rs
@@ -1,11 +1,18 @@
 use std::{
+    cmp::Ordering,
+    ffi::CString,
     hash::{
         Hash,
         Hasher,
     },
-    cmp::Ordering,
+    io,
     os::raw::c_int,
-    sync::Weak,
+    os::unix::ffi::OsStrExt,
+    path::Path,
+    sync::{
+        Arc,
+        Weak,
+    },
 };
 
 use inotify_sys as ffi;
@@ -271,6 +278,175 @@ bitflags! {
         ///
         /// [`inotify_sys::IN_ONLYDIR`]: ../inotify_sys/constant.IN_ONLYDIR.html
         const ONLYDIR = ffi::IN_ONLYDIR;
+    }
+}
+
+
+/// Interface for adding and removing watches
+#[derive(Clone, Debug)]
+pub struct Watches {
+    pub(crate) fd: Arc<FdGuard>,
+}
+
+impl Watches {
+    /// Init watches with an inotify file descriptor
+    pub(crate) fn new(fd: Arc<FdGuard>) -> Self {
+        Watches {
+            fd,
+        }
+    }
+
+    /// Adds or updates a watch for the given path
+    ///
+    /// Adds a new watch or updates an existing one for the file referred to by
+    /// `path`. Returns a watch descriptor that can be used to refer to this
+    /// watch later.
+    ///
+    /// The `mask` argument defines what kind of changes the file should be
+    /// watched for, and how to do that. See the documentation of [`WatchMask`]
+    /// for details.
+    ///
+    /// If this method is used to add a new watch, a new [`WatchDescriptor`] is
+    /// returned. If it is used to update an existing watch, a
+    /// [`WatchDescriptor`] that equals the previously returned
+    /// [`WatchDescriptor`] for that watch is returned instead.
+    ///
+    /// Under the hood, this method just calls [`inotify_add_watch`] and does
+    /// some trivial translation between the types on the Rust side and the C
+    /// side.
+    ///
+    /// # Attention: Updating watches and hardlinks
+    ///
+    /// As mentioned above, this method can be used to update an existing watch.
+    /// This is usually done by calling this method with the same `path`
+    /// argument that it has been called with before. But less obviously, it can
+    /// also happen if the method is called with a different path that happens
+    /// to link to the same inode.
+    ///
+    /// You can detect this by keeping track of [`WatchDescriptor`]s and the
+    /// paths they have been returned for. If the same [`WatchDescriptor`] is
+    /// returned for a different path (and you haven't freed the
+    /// [`WatchDescriptor`] by removing the watch), you know you have two paths
+    /// pointing to the same inode, being watched by the same watch.
+    ///
+    /// # Errors
+    ///
+    /// Directly returns the error from the call to
+    /// [`inotify_add_watch`][`inotify_add_watch`] (translated into an
+    /// `io::Error`), without adding any error conditions of
+    /// its own.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use inotify::{
+    ///     Inotify,
+    ///     WatchMask,
+    /// };
+    ///
+    /// let mut inotify = Inotify::init()
+    ///     .expect("Failed to initialize an inotify instance");
+    ///
+    /// # // Create a temporary file, so `add_watch` won't return an error.
+    /// # use std::fs::File;
+    /// # File::create("/tmp/inotify-rs-test-file")
+    /// #     .expect("Failed to create test file");
+    /// #
+    /// inotify.add_watch("/tmp/inotify-rs-test-file", WatchMask::MODIFY)
+    ///     .expect("Failed to add file watch");
+    ///
+    /// // Handle events for the file here
+    /// ```
+    ///
+    /// [`inotify_add_watch`]: ../inotify_sys/fn.inotify_add_watch.html
+    /// [`WatchMask`]: struct.WatchMask.html
+    /// [`WatchDescriptor`]: struct.WatchDescriptor.html
+    pub fn add<P>(&mut self, path: P, mask: WatchMask)
+                        -> io::Result<WatchDescriptor>
+        where P: AsRef<Path>
+    {
+        let path = CString::new(path.as_ref().as_os_str().as_bytes())?;
+
+        let wd = unsafe {
+            ffi::inotify_add_watch(
+                **self.fd,
+                path.as_ptr() as *const _,
+                mask.bits(),
+            )
+        };
+
+        match wd {
+            -1 => Err(io::Error::last_os_error()),
+            _  => Ok(WatchDescriptor{ id: wd, fd: Arc::downgrade(&self.fd) }),
+        }
+    }
+
+    /// Stops watching a file
+    ///
+    /// Removes the watch represented by the provided [`WatchDescriptor`] by
+    /// calling [`inotify_rm_watch`]. [`WatchDescriptor`]s can be obtained via
+    /// [`Inotify::add_watch`], or from the `wd` field of [`Event`].
+    ///
+    /// # Errors
+    ///
+    /// Directly returns the error from the call to [`inotify_rm_watch`].
+    /// Returns an [`io::Error`] with [`ErrorKind`]`::InvalidInput`, if the given
+    /// [`WatchDescriptor`] did not originate from this [`Inotify`] instance.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use inotify::Inotify;
+    ///
+    /// let mut inotify = Inotify::init()
+    ///     .expect("Failed to initialize an inotify instance");
+    ///
+    /// # // Create a temporary file, so `add_watch` won't return an error.
+    /// # use std::fs::File;
+    /// # let mut test_file = File::create("/tmp/inotify-rs-test-file")
+    /// #     .expect("Failed to create test file");
+    /// #
+    /// # // Add a watch and modify the file, so the code below doesn't block
+    /// # // forever.
+    /// # use inotify::WatchMask;
+    /// # inotify.add_watch("/tmp/inotify-rs-test-file", WatchMask::MODIFY)
+    /// #     .expect("Failed to add file watch");
+    /// # use std::io::Write;
+    /// # write!(&mut test_file, "something\n")
+    /// #     .expect("Failed to write something to test file");
+    /// #
+    /// let mut buffer = [0; 1024];
+    /// let events = inotify
+    ///     .read_events_blocking(&mut buffer)
+    ///     .expect("Error while waiting for events");
+    ///
+    /// for event in events {
+    ///     inotify.rm_watch(event.wd);
+    /// }
+    /// ```
+    ///
+    /// [`WatchDescriptor`]: struct.WatchDescriptor.html
+    /// [`inotify_rm_watch`]: ../inotify_sys/fn.inotify_rm_watch.html
+    /// [`Inotify::add_watch`]: struct.Inotify.html#method.add_watch
+    /// [`Event`]: struct.Event.html
+    /// [`Inotify`]: struct.Inotify.html
+    /// [`io::Error`]: https://doc.rust-lang.org/std/io/struct.Error.html
+    /// [`ErrorKind`]: https://doc.rust-lang.org/std/io/enum.ErrorKind.html
+    pub fn remove(&mut self, wd: WatchDescriptor) -> io::Result<()> {
+        if wd.fd.upgrade().as_ref() != Some(&self.fd) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Invalid WatchDescriptor",
+            ));
+        }
+
+        let result = unsafe { ffi::inotify_rm_watch(**self.fd, wd.id) };
+        match result {
+            0  => Ok(()),
+            -1 => Err(io::Error::last_os_error()),
+            _  => panic!(
+                "unexpected return code from inotify_rm_watch ({})", result)
+        }
     }
 }
 


### PR DESCRIPTION
Adds `Inotify.watches()` and `EventStream.watches()` to get the Watches struct. `Watches::add` and `Watches::remove` are intended to replace the now-deprecated `Inotify::add_watch` and `Inotify::rm_watch`.

Hope I understood the refactoring specifications and scope correctly. Fixes #177 