### PR TITLE
Allow unaligned buffers

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,3 +29,16 @@ jobs:
       run: cargo test --verbose --no-default-features
     - name: Run Clippy lints (no default features)
       run: cargo clippy --verbose --no-default-features -- -D warnings
+
+  miri:
+    name: "Miri"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Miri
+        run: |
+          rustup toolchain install nightly --component miri
+          rustup override set nightly
+          cargo miri setup
+      - name: Test with Miri tests with "from_buffer" in name
+        run: cargo miri test from_buffer

--- a/src/util.rs
+++ b/src/util.rs
@@ -15,35 +15,12 @@ const INOTIFY_EVENT_SIZE: usize = mem::size_of::<ffi::inotify_event>() + 257;
 
 pub fn read_into_buffer(fd: RawFd, buffer: &mut [u8]) -> isize {
     unsafe {
-        // Discard the unaligned portion, if any, of the supplied buffer
-        let buffer = align_buffer_mut(buffer);
-
         ffi::read(
             fd,
             buffer.as_mut_ptr() as *mut c_void,
             buffer.len() as size_t
         )
     }
-}
-
-pub fn align_buffer(buffer: &[u8]) -> &[u8] {
-    if buffer.len() >= mem::align_of::<ffi::inotify_event>() {
-        let ptr = buffer.as_ptr();
-        let offset = ptr.align_offset(mem::align_of::<ffi::inotify_event>());
-        &buffer[offset..]
-    } else {
-        &buffer[0..0]
-    }
-}
-
-pub fn align_buffer_mut(buffer: &mut [u8]) -> &mut [u8] {
-   if buffer.len() >= mem::align_of::<ffi::inotify_event>() {
-        let ptr = buffer.as_mut_ptr();
-        let offset = ptr.align_offset(mem::align_of::<ffi::inotify_event>());
-        &mut buffer[offset..]
-   } else {
-       &mut buffer[0..0]
-   }
 }
 
 /// Get the inotify event buffer size


### PR DESCRIPTION
The key is using [std::ptr::read_unaligned](https://doc.rust-lang.org/std/ptr/fn.read_unaligned.html) to read a struct from an unaligned pointer, instead of the `*` operator to dereference it. `read_unaligned()` permits unaligned pointers, whereas `*` leads to undefined behavior.

Adds a CI test to run [Miri](https://github.com/rust-lang/miri) on the affected code and detect alignment bugs. (Miri cannot be run on all tests, as it cannot make FFI calls for example.)

Fixes #174 