### PR TITLE
Replace event_stream() with into_event_stream()

### DIFF
--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -14,7 +14,7 @@ use tempfile::TempDir;
 
 #[tokio::main]
 async fn main() -> Result<(), io::Error> {
-    let mut inotify = Inotify::init()
+    let inotify = Inotify::init()
         .expect("Failed to initialize inotify");
 
     let dir = TempDir::new()?;
@@ -29,7 +29,7 @@ async fn main() -> Result<(), io::Error> {
     });
 
     let mut buffer = [0; 1024];
-    let mut stream = inotify.event_stream(&mut buffer)?;
+    let mut stream = inotify.into_event_stream(&mut buffer)?;
 
     while let Some(event_or_error) = stream.next().await {
         println!("event: {:?}", event_or_error?);

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -11,14 +11,15 @@ use tokio::io::unix::AsyncFd;
 
 use crate::events::{Event, EventOwned};
 use crate::fd_guard::FdGuard;
+use crate::Inotify;
 use crate::util::read_into_buffer;
 use crate::watches::Watches;
 
 /// Stream of inotify events
 ///
-/// Allows for streaming events returned by [`Inotify::event_stream`].
+/// Allows for streaming events returned by [`Inotify::into_event_stream`].
 ///
-/// [`Inotify::event_stream`]: struct.Inotify.html#method.event_stream
+/// [`Inotify::into_event_stream`]: struct.Inotify.html#method.into_event_stream
 #[derive(Debug)]
 pub struct EventStream<T> {
     fd: AsyncFd<ArcFdGuard>,
@@ -48,6 +49,12 @@ where
     /// [`Watches::remove`]: struct.Watches.html#method.remove
     pub fn watches(&self) -> Watches {
         Watches::new(self.fd.get_ref().0.clone())
+    }
+
+    /// Consumes the `EventStream` instance and returns an `Inotify` using the original
+    /// file descriptor that was passed from `Inotify` to create the `EventStream`.
+    pub fn into_inotify(self) -> Inotify {
+        Inotify::from_file_descriptor(self.fd.into_inner().0)
     }
 }
 


### PR DESCRIPTION
Also adds EventStream.into_inotify() to convert back
to an Inotify.

event_stream() was problematic because it could allow
a caller to inadvertently create multiple streams
reading and contending over the same source, resulting
in unpredictable event emission.

Fixes #176 