### PR TITLE
Implement `AsFd` and bidirectional conversion to/from `OwnedFd`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Install rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.49.0
+        toolchain: 1.63.0
         override: true
         components: clippy
     - name: Check rust and cargo version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ authors = [
   "Frank Denis <github@pureftpd.org>"
 ]
 edition = "2018"
+rust-version = "1.63"
 
 description   = "Idiomatic wrapper for inotify"
 documentation = "https://docs.rs/inotify"

--- a/src/fd_guard.rs
+++ b/src/fd_guard.rs
@@ -1,7 +1,9 @@
 use std::{
     ops::Deref,
     os::unix::io::{
+        AsFd,
         AsRawFd,
+        BorrowedFd,
         FromRawFd,
         IntoRawFd,
         RawFd,
@@ -74,6 +76,13 @@ impl IntoRawFd for FdGuard {
 impl AsRawFd for FdGuard {
     fn as_raw_fd(&self) -> RawFd {
         self.fd
+    }
+}
+
+impl AsFd for FdGuard {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(self.fd) }
     }
 }
 

--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -1,9 +1,12 @@
 use std::{
     io,
     os::unix::io::{
+        AsFd,
         AsRawFd,
+        BorrowedFd,
         FromRawFd,
         IntoRawFd,
+        OwnedFd,
         RawFd,
     },
     path::Path,
@@ -368,5 +371,24 @@ impl IntoRawFd for Inotify {
     fn into_raw_fd(self) -> RawFd {
         self.fd.should_not_close();
         self.fd.fd
+    }
+}
+
+impl AsFd for Inotify {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.fd.as_fd()
+    }
+}
+
+impl From<Inotify> for OwnedFd {
+    fn from(fd: Inotify) -> OwnedFd {
+        unsafe { OwnedFd::from_raw_fd(fd.into_raw_fd()) }
+    }
+}
+
+impl From<OwnedFd> for Inotify {
+    fn from(fd: OwnedFd) -> Inotify {
+        unsafe { Inotify::from_raw_fd(fd.into_raw_fd()) }
     }
 }


### PR DESCRIPTION
In particular, this makes it possible to get a `BorrowedFd` from an
`Inotify`, which allows integration with polling mechanisms that don't
use `RawFd`. This will be needed to work with the next version of
`async-io`.
