### PR TITLE
Re-export `watches::Watches` at crate root.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@ pub use crate::util::{
     get_absolute_path_buffer_size,
 };
 pub use crate::watches::{
+    Watches,
     WatchDescriptor,
     WatchMask,
 };


### PR DESCRIPTION
If `watches::Watches` is not exported publicly, then rustdoc does not show it's documentation, leading to broken doc links in `Inotify::watches`. (it is a `pub` item in a private module, so by default it can be used but not named)

See: [`Inotify::watches`](https://docs.rs/inotify/latest/inotify/struct.Inotify.html#method.watches): the return type does not have an intra-doc link, and the intra-doc links to `Watches::add` and `Watches::remove` lead to 404 pages.