### PR TITLE
Fix the link to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,5 +112,5 @@ THIS SOFTWARE.
 [notify]: https://crates.io/crates/notify
 [inotify-sys]: https://crates.io/crates/inotify-sys
 [API reference]: https://docs.rs/inotify
-[examples directory]: https://github.com/inotify-rs/inotify/tree/master/examples
+[examples directory]: https://github.com/inotify-rs/inotify/tree/main/examples
 [inotify man page]: http://man7.org/linux/man-pages/man7/inotify.7.html


### PR DESCRIPTION
The default branch of this repository is `main`, not `master` now.