### PR TITLE
Update dependency `bitflags` from v1 to v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ stream = ["futures-core", "tokio"]
 
 
 [dependencies]
-bitflags     = "1"
+bitflags     = "2"
 futures-core = { version = "0.3.1", optional = true }
 inotify-sys  = "0.1.3"
 libc         = "0.2"

--- a/src/events.rs
+++ b/src/events.rs
@@ -233,6 +233,7 @@ bitflags! {
     /// Please refer to the documentation of [`Event`] for a usage example.
     ///
     /// [`Event`]: struct.Event.html
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct EventMask: u32 {
         /// File was accessed
         ///

--- a/src/watches.rs
+++ b/src/watches.rs
@@ -63,6 +63,7 @@ bitflags! {
     /// ```
     ///
     /// [`Watches::add`]: struct.Watches.html#method.add
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct WatchMask: u32 {
         /// File was accessed
         ///


### PR DESCRIPTION
This change updates `bitflags` from v1
to [v2][bitflags-2].

`bitflags` v2 no longer implements
`PartialEq`, `Eq`, `PartialOrd`, `Ord`, `Hash`,
`Debug`, `Clone` and `Copy` for generated structs
by default.

For backwards compatibility of `EventMask` and
`WatchMask` (both part of the public API)
these standard traits are deliberately derived,
in line with the rust library
[API guidelines][api-guidelines].

[bitflags-2]: https://github.com/bitflags/bitflags/releases/tag/2.0.0
[api-guidelines]: https://rust-lang.github.io/api-guidelines/interoperability.html#types-eagerly-implement-common-traits-c-common-traits

Implements #210.