### PR TITLE
Add wrapper functions to `bitflags` types

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -357,6 +357,19 @@ bitflags! {
     }
 }
 
+impl EventMask {
+    /// Wrapper around [`Self::from_bits_retain`] for backwards compatibility
+    ///
+    /// # Safety
+    ///
+    /// This function is not actually unsafe. It is just a wrapper around the
+    /// safe [`Self::from_bits_retain`].
+    #[deprecated = "Use the safe `from_bits_retain` method instead"]
+    pub unsafe fn from_bits_unchecked(bits: u32) -> Self {
+        Self::from_bits_retain(bits)
+    }
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/src/watches.rs
+++ b/src/watches.rs
@@ -223,6 +223,19 @@ bitflags! {
     }
 }
 
+impl WatchMask {
+    /// Wrapper around [`Self::from_bits_retain`] for backwards compatibility
+    ///
+    /// # Safety
+    ///
+    /// This function is not actually unsafe. It is just a wrapper around the
+    /// safe [`Self::from_bits_retain`].
+    #[deprecated = "Use the safe `from_bits_retain` method instead"]
+    pub unsafe fn from_bits_unchecked(bits: u32) -> Self {
+        Self::from_bits_retain(bits)
+    }
+}
+
 impl WatchDescriptor {
     /// Getter method for a watcher's id.
     ///


### PR DESCRIPTION
This reduces potential breakage for users of this library.

See https://github.com/bitflags/bitflags/blob/main/CHANGELOG.md#200 for context.