### PR TITLE
Bump minimum supported Rust version (MSRV)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Install rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.63.0
+        toolchain: 1.70.0
         override: true
         components: clippy
     - name: Check rust and cargo version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
   "Frank Denis <github@pureftpd.org>"
 ]
 edition = "2018"
-rust-version = "1.63"
+rust-version = "1.70"
 
 description   = "Idiomatic wrapper for inotify"
 documentation = "https://docs.rs/inotify"


### PR DESCRIPTION
The new MSRV is 1.70, which matches the current MSRV of Tokio.