### PR TITLE
Skip testing code which doesn't compile

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //! ```
 //! When you want to read events asynchronously, you need to convert it to [`EventStream`].
 //! The transform function is [`Inotify::into_event_stream`]
-//! ```
+//! ```skip
 //!  let mut stream = inotify.into_event_stream(&mut buffer)?;
 //!  // Read events from async stream
 //!  while let Some(event_or_error) = stream.next().await {


### PR DESCRIPTION
This sample code isn't standalone, and relies on undeclared variables. Skip it, so that `cargo test` doesn't fail.