### PR TITLE
Add test for DELETE and DELETE_SELF events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ maplit = "1.0"
 rand = "0.8"
 tempfile     = "3.12.0"
 futures-util = "0.3.30"
-tokio        = { version = "1.40.0", features = ["macros", "rt-multi-thread"] }
+tokio        = { version = "1.40.0", features = ["macros", "rt-multi-thread", "time"] }
 
 [[example]]
 name              = "stream"


### PR DESCRIPTION
Trying to find an issue in my own code, I started thinking that this crate might not handle deletion events properly, so I wrote tests to ascertain this. The test pass, so everything is good here. Let's keep the tests in the repository for the next confused soul and for regression testing.