### PR TITLE
Warn about using Vec::with_capacity(4096) as buffer

### DIFF
--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -122,6 +122,9 @@ impl Inotify {
     /// This method calls [`Inotify::read_events`] internally and behaves
     /// essentially the same, apart from the blocking behavior. Please refer to
     /// the documentation of [`Inotify::read_events`] for more information.
+    ///
+    /// Care should be taken when using a [`Vec`] as buffer. See the [crate
+    /// documentation](crate) for details.
     pub fn read_events_blocking<'a>(&mut self, buffer: &'a mut [u8]) -> io::Result<Events<'a>> {
         unsafe {
             let res = fcntl(**self.fd, F_GETFL);
@@ -159,6 +162,9 @@ impl Inotify {
     ///
     /// The `buffer` argument, as the name indicates, is used as a buffer for
     /// the inotify events. Its contents may be overwritten.
+    ///
+    /// Care should be taken when using a [`Vec`] as buffer. See the [crate
+    /// documentation](crate) for details.
     ///
     /// # Errors
     ///
@@ -254,6 +260,9 @@ impl Inotify {
     /// Create a stream which collects events. Consumes the `Inotify` instance.
     ///
     /// Returns a asynchronous `Stream` over the Inotify instance's events.
+    ///
+    /// Care should be taken when using a [`Vec`] as buffer. See the [crate
+    /// documentation](crate) for details.
     #[cfg(feature = "stream")]
     pub fn into_event_stream<T>(self, buffer: T) -> io::Result<EventStream<T>>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,11 @@
 //! [inotify-rs]: https://crates.io/crates/inotify
 //! [inotify]: https://en.wikipedia.org/wiki/Inotify
 //! [inotify man pages]: http://man7.org/linux/man-pages/man7/inotify.7.html
+//!
+//! # `Vec` as buffers
+//!
+//! Using a `Vec::with_capacity(4096)` as a buffer is problematic, since this buffer has reserved
+//! capacity but length `0`. Use `vec![0u8; 4096]` instead.
 
 #![deny(missing_docs)]
 #![deny(warnings)]


### PR DESCRIPTION
Using `Vec::with_capacity(4096)` results in errors attempting to read events since it's treated as a zero-length buffer. Warn about this.