### PR TITLE
Ignore feature-gated code in rustdoc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //! ```
 //! When you want to read events asynchronously, you need to convert it to [`EventStream`].
 //! The transform function is [`Inotify::into_event_stream`]
-//! ```
+//! ```ignore
 //! # async fn stream_events() {
 //! # use futures_util::StreamExt;
 //! #


### PR DESCRIPTION
CI is currently failing for `cargo test --no-default-features` because one of the rustdoc examples uses feature-gated types.

Disable testing this particular block.