### PR TITLE
feat: allow comparison of duplicate descriptors by using kcmp

### DIFF
--- a/src/fd_guard.rs
+++ b/src/fd_guard.rs
@@ -6,6 +6,8 @@ use std::{
 
 use inotify_sys as ffi;
 
+use crate::util;
+
 /// A RAII guard around a `RawFd` that closes it automatically on drop.
 #[derive(Debug)]
 pub struct FdGuard {
@@ -78,6 +80,28 @@ impl AsFd for FdGuard {
 
 impl PartialEq for FdGuard {
     fn eq(&self, other: &FdGuard) -> bool {
-        self.fd == other.fd
+        let initial = self.fd == other.fd;
+        if initial {
+            return true;
+        }
+        // This allows comparing duplicated Inotify descriptors that point to the
+        // same Inotify instance, which allows for scenarios where an Inotify
+        // wrapper both owns a file descriptor for control purposes and spawns a
+        // second thread that needs a separate unowned descriptor to use the `epoll`
+        // crate.
+        let current_process = std::process::id();
+        let result = match util::cvt(unsafe {
+            libc::syscall(
+                libc::SYS_kcmp,
+                current_process,
+                current_process,
+                self.fd,
+                other.fd,
+            ) as i64
+        }) {
+            Err(_) => false,
+            Ok(cmp) => cmp == 0,
+        };
+        result
     }
 }

--- a/src/fd_guard.rs
+++ b/src/fd_guard.rs
@@ -87,7 +87,7 @@ impl PartialEq for FdGuard {
         // This allows comparing duplicated Inotify descriptors that point to the
         // same Inotify instance, which allows for scenarios where an Inotify
         // wrapper both owns a file descriptor for control purposes and spawns a
-        // second thread that needs a separate unowned descriptor to use the `epoll`
+        // second thread that needs a separate unowned descriptor to use the `epoll-rs`
         // crate.
         let current_process = std::process::id();
         let result = match util::cvt(unsafe {

--- a/src/fd_guard.rs
+++ b/src/fd_guard.rs
@@ -89,12 +89,14 @@ impl PartialEq for FdGuard {
         // wrapper both owns a file descriptor for control purposes and spawns a
         // second thread that needs a separate unowned descriptor to use the `epoll-rs`
         // crate.
+        const KCMP_FILE: i32 = 0;
         let current_process = std::process::id();
         let result = match util::cvt(unsafe {
             libc::syscall(
                 libc::SYS_kcmp,
                 current_process,
                 current_process,
+                KCMP_FILE,
                 self.fd,
                 other.fd,
             ) as i64

--- a/src/fd_guard.rs
+++ b/src/fd_guard.rs
@@ -91,7 +91,7 @@ impl PartialEq for FdGuard {
         // crate.
         const KCMP_FILE: i32 = 0;
         let current_process = std::process::id();
-        let result = match util::cvt(unsafe {
+        let result = match util::libc_convert(unsafe {
             libc::syscall(
                 libc::SYS_kcmp,
                 current_process,

--- a/src/util.rs
+++ b/src/util.rs
@@ -62,7 +62,7 @@ pub fn get_absolute_path_buffer_size(path: &Path) -> usize {
 
 /// Converts Linux return integers to Result using the *-1 means error is in `errno`*  convention.
 /// Non-error values are `Ok`-wrapped.
-pub fn cvt<T: Into<i64> + Copy>(t: T) -> io::Result<T> {
+pub fn libc_convert<T: Into<i64> + Copy>(t: T) -> io::Result<T> {
     if t.into() == -1 {
         Err(io::Error::last_os_error())
     } else {

--- a/src/util.rs
+++ b/src/util.rs
@@ -59,3 +59,13 @@ pub fn get_absolute_path_buffer_size(path: &Path) -> usize {
 
     INOTIFY_EVENT_SIZE + parent_path_len
 }
+
+/// Converts Linux return integers to Result using the *-1 means error is in `errno`*  convention.
+/// Non-error values are `Ok`-wrapped.
+pub fn cvt<T: Into<i64> + Copy>(t: T) -> io::Result<T> {
+    if t.into() == -1 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(t)
+    }
+}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -8,6 +8,7 @@ use std::fs::File;
 use std::io::{ErrorKind, Write};
 #[cfg(feature = "stream")]
 use std::mem;
+use std::os::fd::AsFd;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
 use std::path::PathBuf;
 use tempfile::TempDir;
@@ -313,6 +314,31 @@ fn it_should_watch_correctly_with_a_watches_clone() {
         num_events += 1;
     }
     assert!(num_events > 0);
+}
+
+#[test]
+fn watch_descriptor_equality_should_work_for_multiple_fds_of_same_instance() {
+    let mut testdir = TestDir::new();
+    let (path, _) = testdir.new_file();
+    let inotify = Inotify::init().unwrap();
+    // Clone the fd of the inotify instance to create a second reference to the same instance
+    let second_inotify_reference = Inotify::from(
+        inotify
+            .as_fd()
+            .try_clone_to_owned()
+            .expect("failed to clone fd of inotify"),
+    );
+    // Since both descriptors point to the same inotify instance, attempting to add a watch twice
+    // should return the same watch descriptor
+    let first_watch = inotify.watches().add(&path, WatchMask::MODIFY).unwrap();
+    let second_watch = second_inotify_reference
+        .watches()
+        .add(&path, WatchMask::MODIFY)
+        .unwrap();
+    assert_eq!(
+        first_watch, second_watch,
+        "first and second watch descriptors should be equal"
+    );
 }
 
 #[cfg(feature = "stream")]


### PR DESCRIPTION
This addition allows for scenarios where multiple threads need lock-free and direct control over the `Inotify` instance, such as in a reference-counted wrapper implementation that with a dedicated thread that reads and sends events to a channel. The wrapper struct must own the first `Inotify` descriptor to control watches, and the dedicated thread must use the `epoll_rs::Epoll` struct and listen for changes while remaining cancellable by also listening to a `PipeWriter`. The `Epoll` struct in question requires that all file descriptors passed to its API are unowned, so `libc::dup` has to be used to create another descriptor to the same `Inotify` instance.