### PR TITLE
Replace futures-core with futures-util to enable StreamExt re-exports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,12 @@ exclude    = ["/inotify-rs.sublime-project"]
 
 [features]
 default = ["stream"]
-stream = ["futures-core", "tokio"]
+stream = ["futures-util", "tokio"]
 
 
 [dependencies]
 bitflags     = "2"
-futures-core = { version = "0.3.30", optional = true }
+futures-util = { version = "0.3.30", optional = true }
 inotify-sys  = "0.1.5"
 libc         = "0.2"
 tokio        = { version = "1.40.0", optional = true, features = ["net"] }

--- a/README.md
+++ b/README.md
@@ -64,8 +64,7 @@ Perhaps you want asynchronous monitoring of events. An example of asynchronous i
 ```rust
 use std::{fs::File, io, thread, time::Duration};
 
-use futures_util::StreamExt;
-use inotify::{Inotify, WatchMask};
+use inotify::{Inotify, StreamExt, WatchMask};
 use tempfile::TempDir;
 
 #[tokio::main]

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -1,7 +1,6 @@
 use std::{fs::File, io, thread, time::Duration};
 
-use futures_util::StreamExt;
-use inotify::{Inotify, WatchMask};
+use inotify::{Inotify, StreamExt, WatchMask};
 use tempfile::TempDir;
 
 #[tokio::main]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //! The transform function is [`Inotify::into_event_stream`]
 //! ```
 //! # async fn stream_events() {
-//! # use futures_util::StreamExt;
+//! # use inotify::StreamExt;
 //! #
 //! # let mut inotify = inotify::Inotify::init()
 //! #     .expect("Error while initializing inotify instance");
@@ -116,3 +116,5 @@ pub use crate::watches::{WatchDescriptor, WatchMask, Watches};
 
 #[cfg(feature = "stream")]
 pub use self::stream::EventStream;
+#[cfg(feature = "stream")]
+pub use futures_util::{Stream, StreamExt};

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -6,7 +6,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures_core::{ready, Stream};
+use futures_util::{ready, Stream};
 use tokio::io::unix::AsyncFd;
 
 use crate::events::{Event, EventOwned};

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -3,6 +3,8 @@
 // This test suite is incomplete and doesn't cover all available functionality.
 // Contributions to improve test coverage would be highly appreciated!
 
+#[cfg(feature = "stream")]
+use inotify::StreamExt;
 use inotify::{EventMask, Inotify, WatchMask};
 use std::fs::File;
 use std::io::{ErrorKind, Write};
@@ -13,7 +15,7 @@ use std::path::PathBuf;
 use tempfile::TempDir;
 
 #[cfg(feature = "stream")]
-use futures_util::{FutureExt, StreamExt};
+use futures_util::FutureExt;
 #[cfg(feature = "stream")]
 use maplit::hashmap;
 #[cfg(feature = "stream")]
@@ -63,7 +65,6 @@ async fn it_should_watch_a_file_async() {
 
     let mut buffer = [0; 1024];
 
-    use futures_util::StreamExt;
     let events = inotify
         .into_event_stream(&mut buffer[..])
         .unwrap()
@@ -89,7 +90,6 @@ async fn it_should_watch_a_file_from_eventstream_watches() {
 
     let mut buffer = [0; 1024];
 
-    use futures_util::StreamExt;
     let stream = inotify.into_event_stream(&mut buffer[..]).unwrap();
 
     // Hold ownership of `watches` for this test, so that the underlying file descriptor has


### PR DESCRIPTION
Switching to futures-util allows re‑exporting the StreamExt trait and using the crates async APIs without requiring an additional downstream dependency.

Resolves #253