### PR TITLE
Bump inotify-sys to 0.1.7, add `WatchMask::MASK_CREATE` option.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ stream = ["futures-util", "tokio"]
 [dependencies]
 bitflags     = "2"
 futures-util = { version = "0.3.30", optional = true }
-inotify-sys  = "0.1.5"
+inotify-sys  = "0.1.7"
 libc         = "0.2"
 tokio        = { version = "1.40.0", optional = true, features = ["net"] }
 

--- a/src/watches.rs
+++ b/src/watches.rs
@@ -200,10 +200,15 @@ bitflags! {
         /// See [`inotify_sys::IN_EXCL_UNLINK`].
         const EXCL_UNLINK = ffi::IN_EXCL_UNLINK;
 
-        /// If a watch for the inode exists, amend it instead of replacing it
+        /// If a watch for the inode exists, amend it instead of replacing it. Conflicts with [`WatchMask::MASK_CREATE`].
         ///
         /// See [`inotify_sys::IN_MASK_ADD`].
         const MASK_ADD = ffi::IN_MASK_ADD;
+
+        /// Only create watches, errors if a watch on this inode already exists. Conflicts with [`WatchMask::MASK_ADD`].
+        ///
+        /// See [`inotify_sys::IN_MASK_CREATE`].
+        const MASK_CREATE = ffi::IN_MASK_CREATE;
 
         /// Only receive one event, then remove the watch
         ///


### PR DESCRIPTION
This PR bumps the version of `inotify-sys` to 0.1.7, which contains the `IN_MASK_CREATE` constant.

It also added a bitflag `MASK_CREATE` to WatchMask, mirroring that constant.

`inotify-sys` 0.1.7 also contain the `freebsd-native`. There seems to be ongoing work with FreeBSD builds in #258, which also bumps `inotify-sys`. Maybe I should wait after that's merged, and then rebase onto it?